### PR TITLE
filter call and chat conversations

### DIFF
--- a/backend-node/routes/auth.js
+++ b/backend-node/routes/auth.js
@@ -166,7 +166,7 @@ authRoutes.post('/login', async (req, res) => {
       delete user.vonage_id;
       const token = JWT.getUserJWT(user.name, user.id);
       let users = await Data.users.getInterlocutorsFor(client, user.name);
-      const conversations = await Data.conversations.getAllForUser(client, user.id);
+      const conversations = await Data.conversations.getAllForUser(client, user.id, true);
       jsonResponse = {
         user,
         token,

--- a/backend-node/routes/vonage.js
+++ b/backend-node/routes/vonage.js
@@ -80,7 +80,7 @@ vonageRoutes.get('/conversations', async (req, res) => {
   const pool = new Pool({ connectionString: process.env.postgresDatabaseUrl });
   pool.connect(async (err, client, done) => {
     if (err) throw err
-    const vonageConversations = await Data.conversations.getAllForUser(client, req.user.user_id);
+    const vonageConversations = await Data.conversations.getAllForUser(client, req.user.user_id, true);
     client.release();
     return res.status(200).json(vonageConversations);
   });


### PR DESCRIPTION
I added a column to the conversations table on the database called `is_chat`. It defaults to FALSE so any conversations added will automatically be false. So conversations created by Vonage, calls, will have `is_chat` set to false on the database when they get synced. 

This PR ensures that conversations created by Vapp, which are chats, set this database flag to true.

EDIT: Moving below to separate PR
The second commit on this PR adds a `GET/calls` endpoint which works exactly the same as the `GET/conversations` but it just returns any conversation that has the `is_chat` flag set to false. This will allow us to build a call screen where you can see the past calls that have been made etc. 