### PR TITLE
standardise baseurls

### DIFF
--- a/client-android/app/src/main/java/com/vonage/vapp/data/ApiRepository.kt
+++ b/client-android/app/src/main/java/com/vonage/vapp/data/ApiRepository.kt
@@ -33,7 +33,7 @@ object ApiRepository {
     private val moshi = Moshi.Builder().build();
 
     private val retrofit = Retrofit.Builder()
-        .baseUrl("https://v-app-companion.herokuapp.com/")
+        .baseUrl("VAPP_BASE_URL/")
         .addConverterFactory(MoshiConverterFactory.create(moshi))
         .client(client)
         .build()

--- a/client-ios/TheApp/Helpers/RemoteLoader.swift
+++ b/client-ios/TheApp/Helpers/RemoteLoader.swift
@@ -9,7 +9,7 @@ enum RemoteLoaderError: Error {
 
 final class RemoteLoader {
     
-    static let baseURL = ""
+    static let baseURL = "VAPP_BASE_URL"
         
     static func load<T: Codable, U: Codable>(path: String,
                                              authToken: String? = nil,


### PR DESCRIPTION
To allow for the vapp plugin to replace them with the correct URL